### PR TITLE
Change behavior to use new `TerminalQueryAPI`

### DIFF
--- a/TerminalConsumables/API/TerminalAPI.cs
+++ b/TerminalConsumables/API/TerminalAPI.cs
@@ -18,7 +18,7 @@ namespace TerminalConsumables.API
     /// PING STATUS: ...</code>
     /// </param>
     /// <returns></returns>
-    public delegate List<string> QueryTextOverride(Item item, iTerminalItem terminalItem, List<string> defaultDetails);
+    public delegate List<string> QueryTextOverride(ItemInLevel item, iTerminalItem terminalItem, List<string> defaultDetails);
 
     public static class TerminalAPI
     {
@@ -31,7 +31,7 @@ namespace TerminalConsumables.API
         /// <returns>
         /// A struct containing the newly created iTerminalItem and its item key string.
         /// </returns>
-        public static iTerminalItem RegisterTerminalItem(Item item,  bool ammoRel = true, QueryTextOverride? queryOverride = null) => TerminalItemManager.AddTerminalItem(item, ammoRel, queryOverride);
+        public static iTerminalItem RegisterTerminalItem(ItemInLevel item,  bool ammoRel = true, QueryTextOverride? queryOverride = null) => TerminalItemManager.AddTerminalItem(item, ammoRel, queryOverride);
 
         /// <summary>
         /// Modifies query-related options for the terminal item. If the item is not tracked, it is registered as a tracked item.
@@ -53,6 +53,6 @@ namespace TerminalConsumables.API
         /// <returns>
         /// A struct containing the newly created iTerminalItem and its item key string.
         /// </returns>
-        public static bool ModifyTerminalItem(Item item, bool ammoRel = true, QueryTextOverride? queryOverride = null) => ModifyTerminalItem(item.GetComponent<iTerminalItem>(), ammoRel, queryOverride);
+        public static bool ModifyTerminalItem(ItemInLevel item, bool ammoRel = true, QueryTextOverride? queryOverride = null) => ModifyTerminalItem(item.GetComponent<iTerminalItem>(), ammoRel, queryOverride);
     }
 }

--- a/TerminalConsumables/Dependencies.props
+++ b/TerminalConsumables/Dependencies.props
@@ -34,5 +34,6 @@
 	<!-- Plugins -->
 	<ItemGroup>
 		<Reference Include="$(PluginsFolder)/GTFO-API.dll" Private="false" />
+    <Reference Include="$(PluginsFolder)/*TerminalQueryAPI/TerminalQueryAPI.dll" Private="false" />
 	</ItemGroup>
 </Project>

--- a/TerminalConsumables/EntryPoint.cs
+++ b/TerminalConsumables/EntryPoint.cs
@@ -2,11 +2,13 @@
 using BepInEx.Unity.IL2CPP;
 using HarmonyLib;
 using TerminalConsumables.Managers;
+using TerminalQueryAPI;
 
 namespace TerminalConsumables
 {
     [BepInPlugin("Dinorush." + MODNAME, MODNAME, "1.1.1")]
     [BepInDependency("dev.gtfomodding.gtfo-api", BepInDependency.DependencyFlags.HardDependency)]
+    [BepInDependency(QueryableAPI.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     internal sealed class EntryPoint : BasePlugin
     {
         public const string MODNAME = "TerminalConsumables";

--- a/TerminalConsumables/Manager/TerminalItemManager.cs
+++ b/TerminalConsumables/Manager/TerminalItemManager.cs
@@ -12,7 +12,7 @@ namespace TerminalConsumables.Managers
 
         public struct QueryInfo
         {
-            public Item item;
+            public ItemInLevel item;
             public bool ammoRel;
             public QueryTextOverride? queryTextOverride;
         }
@@ -34,7 +34,7 @@ namespace TerminalConsumables.Managers
             return QueryableAPI.ModifyQueryableItem(terminalItem, GetQueryDelegate(queryInfo.item, terminalItem, queryInfo.ammoRel, queryInfo.queryTextOverride));
         }
 
-        public static iTerminalItem AddTerminalItem(Item item, bool ammoRel = true, QueryTextOverride? queryOverride = null)
+        public static iTerminalItem AddTerminalItem(ItemInLevel item, bool ammoRel = true, QueryTextOverride? queryOverride = null)
         {
             var terminalItem = item.GetComponent<iTerminalItem>();
             if (terminalItem != null)
@@ -54,8 +54,7 @@ namespace TerminalConsumables.Managers
 
             terminalItem.Setup(itemKey);
             
-            var sync = item.TryCast<ItemInLevel>()?.internalSync;
-            sync?.add_OnSyncStateChange((Action<ePickupItemStatus, pPickupPlacement, Player.PlayerAgent, bool>)(
+            item.internalSync.add_OnSyncStateChange((Action<ePickupItemStatus, pPickupPlacement, Player.PlayerAgent, bool>)(
                 (ePickupItemStatus status, pPickupPlacement placement, Player.PlayerAgent player, bool isRecall) =>
                 {
                     switch (status)
@@ -83,7 +82,7 @@ namespace TerminalConsumables.Managers
             return terminalItem;
         }
 
-        public static QueryDelegate GetQueryDelegate(Item item, iTerminalItem terminalItem, bool ammoRel = true, QueryTextOverride? queryOverride = null)
+        public static QueryDelegate GetQueryDelegate(ItemInLevel item, iTerminalItem terminalItem, bool ammoRel = true, QueryTextOverride? queryOverride = null)
         {
             var consumable = item.TryCast<ConsumablePickup_Core>();
             if (queryOverride != null)

--- a/TerminalConsumables/Manager/TerminalItemManager.cs
+++ b/TerminalConsumables/Manager/TerminalItemManager.cs
@@ -115,42 +115,6 @@ namespace TerminalConsumables.Managers
             return output;
         }
 
-        public static void DoQueryOutput(iTerminalItem terminalItem, LG_ComputerTerminalCommandInterpreter interpreter)
-        {
-            if (!_terminalInfo.TryGetValue(terminalItem.Pointer, out var queryInfo)) return;
-
-            var item = queryInfo.item;
-
-            string pingStatus = interpreter.GetPingStatus(terminalItem);
-            var details = interpreter.GetDefaultDetails(terminalItem, pingStatus);
-            List<string> defaultDetails = new(details.Count);
-            foreach (string line in details)
-                defaultDetails.Add(line);
-
-            List<string> output;
-            if (queryInfo.queryTextOverride != null)
-                output = queryInfo.queryTextOverride(item, terminalItem, defaultDetails);
-            else
-            {
-                var datablock = item.ItemDataBlock;
-                output = new()
-                {
-                    "----------------------------------------------------------------",
-                    "CONSUMABLE - " + datablock.terminalItemLongName.ToString()
-                };
-                if (datablock.ConsumableAmmoMax > 0 && queryInfo.ammoRel)
-                    output.Add("CAPACITY: " + (item.pItemData.custom.ammo / datablock.ConsumableAmmoMax).ToString("P0"));
-                else
-                    output.Add("CAPACITY: " + item.pItemData.custom.ammo.ToString("N0"));
-                output.AddRange(defaultDetails);
-            }
-
-            foreach (var line in output)
-                interpreter.AddOutput(line, spacing: false);
-        }
-
-        public static bool HasTerminal(iTerminalItem terminalItem) => _terminalInfo.ContainsKey(terminalItem.Pointer);
-
         internal static void OnLevelCleanup()
         {
             _terminalInfo.Clear();

--- a/TerminalConsumables/Patches/PickupPatches.cs
+++ b/TerminalConsumables/Patches/PickupPatches.cs
@@ -29,20 +29,5 @@ namespace TerminalConsumables.Patches
                 __instance.m_terminalItem.FloorItemLocation = courseNode.m_zone.NavInfo.GetFormattedText(LG_NavInfoFormat.Full_And_Number_With_Underscore);
             }
         }
-
-        [HarmonyPatch(typeof(LG_ComputerTerminalCommandInterpreter), nameof(LG_ComputerTerminalCommandInterpreter.Query))]
-        [HarmonyPrefix]
-        static bool Prefix(LG_ComputerTerminalCommandInterpreter __instance, string param1)
-        {
-            if (!LG_LevelInteractionManager.TryGetTerminalInterface(param1.ToUpper(), __instance.m_terminal.SpawnNode.m_dimension.DimensionIndex, out var target)) return true;
-
-            if (!TerminalItemManager.HasTerminal(target)) return true;
-
-            __instance.AddOutput(TerminalLineType.SpinningWaitDone, "Querying " + param1.ToUpper(), 3f);
-            __instance.AddOutputEmptyLine();
-            TerminalItemManager.DoQueryOutput(target, __instance);
-            __instance.AddOutputEmptyLine();
-            return false;
-        }
     }
 }


### PR DESCRIPTION
This PR removes the Terminal Interpreter patch to instead make use of [TerminalQueryAPI](https://thunderstore.io/c/gtfo/p/JarheadHME/TerminalQueryAPI/)

TerminalConsumables is still good as an API for ItemInLevel querys, so its own API was kept, and interfaces with the QueryAPI instead for the actual management of the querying. 

Also, since `Item` includes first person equippables, the ItemInLevel restriction was reinstated.

Finally, a minor change was made to the actual consumable querying, where if the consumable's datablock says to show the ammo as infinite, then the capacity line is omitted from the query details.